### PR TITLE
Multiple models

### DIFF
--- a/Lumina.podspec
+++ b/Lumina.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "Lumina"
-  s.version     = "0.12.0"
+  s.version     = "0.13.0"
   s.summary     = "Lumina gives you a camera for most photo processing needs, including streaming frames for CoreML live detection."
   s.homepage    = "https://github.com/dokun1/Lumina"
   s.license     = { :type => "MIT" }

--- a/Lumina/Lumina/Camera/Extensions/Delegates/VideoDataOutputSampleBufferDelegateExtension.swift
+++ b/Lumina/Lumina/Camera/Extensions/Delegates/VideoDataOutputSampleBufferDelegateExtension.swift
@@ -15,9 +15,9 @@ extension LuminaCamera: AVCaptureVideoDataOutputSampleBufferDelegate {
             return
         }
         if #available(iOS 11.0, *) {
-            if let models = self.streamingModels {
+            if let modelPairs = self.streamingModels {
                 if self.recognizer == nil {
-                    let newRecognizer = LuminaObjectRecognizer(models: models)
+                    let newRecognizer = LuminaObjectRecognizer(modelPairs: modelPairs)
                     self.recognizer = newRecognizer
                 }
                 guard let recognizer = self.recognizer as? LuminaObjectRecognizer else {

--- a/Lumina/Lumina/Camera/LuminaCamera.swift
+++ b/Lumina/Lumina/Camera/LuminaCamera.swift
@@ -15,7 +15,7 @@ protocol LuminaCameraDelegate: class {
     func videoFrameCaptured(camera: LuminaCamera, frame: UIImage)
     func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [LuminaPrediction]?)
     @available (iOS 11.0, *)
-    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, MLModel.Type)])
+    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, MLModel.Type)]?)
     func depthDataCaptured(camera: LuminaCamera, depthData: Any)
     func videoRecordingCaptured(camera: LuminaCamera, videoURL: URL)
     func finishedFocus(camera: LuminaCamera)

--- a/Lumina/Lumina/Camera/LuminaCamera.swift
+++ b/Lumina/Lumina/Camera/LuminaCamera.swift
@@ -14,6 +14,8 @@ protocol LuminaCameraDelegate: class {
     func stillImageCaptured(camera: LuminaCamera, image: UIImage, livePhotoURL: URL?, depthData: Any?)
     func videoFrameCaptured(camera: LuminaCamera, frame: UIImage)
     func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [LuminaPrediction]?)
+    @available (iOS 11.0, *)
+    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, MLModel.Type)])
     func depthDataCaptured(camera: LuminaCamera, depthData: Any)
     func videoRecordingCaptured(camera: LuminaCamera, videoURL: URL)
     func finishedFocus(camera: LuminaCamera)

--- a/Lumina/Lumina/Camera/LuminaCamera.swift
+++ b/Lumina/Lumina/Camera/LuminaCamera.swift
@@ -15,7 +15,7 @@ protocol LuminaCameraDelegate: class {
     func videoFrameCaptured(camera: LuminaCamera, frame: UIImage)
     func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [LuminaPrediction]?)
     @available (iOS 11.0, *)
-    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, String)]?)
+    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, Any.Type)]?)
     func depthDataCaptured(camera: LuminaCamera, depthData: Any)
     func videoRecordingCaptured(camera: LuminaCamera, videoURL: URL)
     func finishedFocus(camera: LuminaCamera)
@@ -149,12 +149,12 @@ final class LuminaCamera: NSObject {
 
     var recognizer: AnyObject?
 
-    private var _streamingModels: [(AnyObject, String)]?
+    private var _streamingModels: [(AnyObject, Any.Type)]?
     @available(iOS 11.0, *)
-    var streamingModels: [(MLModel, String)]? {
+    var streamingModels: [(MLModel, Any.Type)]? {
         get {
             if let existingModels = _streamingModels {
-                var models = [(MLModel, String)]()
+                var models = [(MLModel, Any.Type)]()
                 for potentialModel in existingModels {
                     if let model = potentialModel.0 as? MLModel {
                         models.append((model, potentialModel.1))
@@ -170,7 +170,7 @@ final class LuminaCamera: NSObject {
         }
         set {
             if let tuples = newValue {
-                var downcastCollection = [(AnyObject, String)]()
+                var downcastCollection = [(AnyObject, Any.Type)]()
                 for tuple in tuples {
                     downcastCollection.append((tuple.0 as AnyObject, tuple.1))
                 }

--- a/Lumina/Lumina/Camera/LuminaCamera.swift
+++ b/Lumina/Lumina/Camera/LuminaCamera.swift
@@ -15,7 +15,7 @@ protocol LuminaCameraDelegate: class {
     func videoFrameCaptured(camera: LuminaCamera, frame: UIImage)
     func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [LuminaPrediction]?)
     @available (iOS 11.0, *)
-    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, MLModel.Type)]?)
+    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, String)]?)
     func depthDataCaptured(camera: LuminaCamera, depthData: Any)
     func videoRecordingCaptured(camera: LuminaCamera, videoURL: URL)
     func finishedFocus(camera: LuminaCamera)
@@ -149,15 +149,15 @@ final class LuminaCamera: NSObject {
 
     var recognizer: AnyObject?
 
-    private var _streamingModels: [AnyObject]?
+    private var _streamingModels: [(AnyObject, String)]?
     @available(iOS 11.0, *)
-    var streamingModels: [MLModel]? {
+    var streamingModels: [(MLModel, String)]? {
         get {
             if let existingModels = _streamingModels {
-                var models = [MLModel]()
+                var models = [(MLModel, String)]()
                 for potentialModel in existingModels {
-                    if let model = potentialModel as? MLModel {
-                        models.append(model)
+                    if let model = potentialModel.0 as? MLModel {
+                        models.append((model, potentialModel.1))
                     }
                 }
                 guard models.count > 0 else {
@@ -169,9 +169,12 @@ final class LuminaCamera: NSObject {
             }
         }
         set {
-            if newValue != nil {
-                _streamingModels = newValue
-//                recognizer = LuminaObjectRecognizer(model: newValue!)
+            if let tuples = newValue {
+                var downcastCollection = [(AnyObject, String)]()
+                for tuple in tuples {
+                    downcastCollection.append((tuple.0 as AnyObject, tuple.1))
+                }
+                _streamingModels = downcastCollection
             }
         }
     }

--- a/Lumina/Lumina/Camera/LuminaCamera.swift
+++ b/Lumina/Lumina/Camera/LuminaCamera.swift
@@ -147,16 +147,29 @@ final class LuminaCamera: NSObject {
 
     var recognizer: AnyObject?
 
-    private var _streamingModel: AnyObject?
+    private var _streamingModels: [AnyObject]?
     @available(iOS 11.0, *)
-    var streamingModel: MLModel? {
+    var streamingModels: [MLModel]? {
         get {
-            return _streamingModel as? MLModel
+            if let existingModels = _streamingModels {
+                var models = [MLModel]()
+                for potentialModel in existingModels {
+                    if let model = potentialModel as? MLModel {
+                        models.append(model)
+                    }
+                }
+                guard models.count > 0 else {
+                    return nil
+                }
+                return models
+            } else {
+                return nil
+            }
         }
         set {
             if newValue != nil {
-                _streamingModel = newValue
-                recognizer = LuminaObjectRecognizer(model: newValue!)
+                _streamingModels = newValue
+//                recognizer = LuminaObjectRecognizer(model: newValue!)
             }
         }
     }

--- a/Lumina/Lumina/Camera/LuminaObjectRecognizer.swift
+++ b/Lumina/Lumina/Camera/LuminaObjectRecognizer.swift
@@ -20,14 +20,14 @@ public struct LuminaPrediction {
 
 @available(iOS 11.0, *)
 final class LuminaObjectRecognizer: NSObject {
-    private var modelPairs: [(MLModel, String)]
+    private var modelPairs: [(MLModel, Any.Type)]
 
-    init(modelPairs: [(MLModel, String)]) {
+    init(modelPairs: [(MLModel, Any.Type)]) {
         self.modelPairs = modelPairs
     }
 
-    func recognize(from image: UIImage, completion: @escaping ([([LuminaPrediction]?, String)]) -> Void) {
-        var recognitionResults = [([LuminaPrediction]?, String)]()
+    func recognize(from image: UIImage, completion: @escaping ([([LuminaPrediction]?, Any.Type)]) -> Void) {
+        var recognitionResults = [([LuminaPrediction]?, Any.Type)]()
         let recognitionGroup = DispatchGroup()
         for modelPair in modelPairs {
             recognitionGroup.enter()

--- a/Lumina/Lumina/Camera/LuminaObjectRecognizer.swift
+++ b/Lumina/Lumina/Camera/LuminaObjectRecognizer.swift
@@ -20,18 +20,18 @@ public struct LuminaPrediction {
 
 @available(iOS 11.0, *)
 final class LuminaObjectRecognizer: NSObject {
-    private var models: [MLModel]
+    private var modelPairs: [(MLModel, String)]
 
-    init(models: [MLModel]) {
-        self.models = models
+    init(modelPairs: [(MLModel, String)]) {
+        self.modelPairs = modelPairs
     }
 
-    func recognize(from image: UIImage, completion: @escaping ([([LuminaPrediction]?, MLModel.Type)]) -> Void) {
-        var recognitionResults = [([LuminaPrediction]?, MLModel.Type)]()
+    func recognize(from image: UIImage, completion: @escaping ([([LuminaPrediction]?, String)]) -> Void) {
+        var recognitionResults = [([LuminaPrediction]?, String)]()
         let recognitionGroup = DispatchGroup()
-        for model in models {
+        for modelPair in modelPairs {
             recognitionGroup.enter()
-            guard let visionModel = try? VNCoreMLModel(for: model) else {
+            guard let visionModel = try? VNCoreMLModel(for: modelPair.0) else {
                 recognitionGroup.leave()
                 continue
             }
@@ -40,7 +40,7 @@ final class LuminaObjectRecognizer: NSObject {
                     recognitionGroup.leave()
                 } else if let results = request.results {
                     let mappedResults = self.mapResults(results)
-                    recognitionResults.append((mappedResults, type(of: model)))
+                    recognitionResults.append((mappedResults, modelPair.1))
                     recognitionGroup.leave()
                 }
             }

--- a/Lumina/Lumina/Camera/LuminaObjectRecognizer.swift
+++ b/Lumina/Lumina/Camera/LuminaObjectRecognizer.swift
@@ -25,43 +25,6 @@ final class LuminaObjectRecognizer: NSObject {
     init(models: [MLModel]) {
         self.models = models
     }
-/*
-     router.get("/animals/:animals/friendly/:friendly/plural/:plural") { request, response, next in
-     let animalGroup = DispatchGroup()
-     var animals = [Animal]()
-     for address in ["http://0.0.0.0:3030/api/Cats", "http://0.0.0.0:3001/api/Bears"] {
-     guard let url = URL(string: address) else {
-     return
-     }
-     animalGroup.enter()
-     fetch(url, completion: { fetchedAnimals, error in
-     if let fetchedAnimals = fetchedAnimals {
-     animals.append(contentsOf: fetchedAnimals)
-     }
-     animalGroup.leave()
-     })
-     }
-     
-     animalGroup.notify(queue: DispatchQueue.global(qos: .default)) {
-     animals = filter(animals, request)
-     var results = [[String: AnyObject]]()
-     for animal in animals {
-     results.append(animal.json)
-     }
-     response.send(json: JSON(results))
-     next()
-     }
-     }*/
-    
-    
-    /* func doSomething<T>(a: AnyObject, myType: T.Type) {
-     if let a = a as? T {
-     //…
-     }
-     }
-     
-     // usage
-     doSomething("Hello World", myType: String.self)*/
     
     func recognize(from image: UIImage, completion: @escaping ([([LuminaPrediction]?, MLModel.Type)]) -> Void) {
         var recognitionResults = [([LuminaPrediction]?, MLModel.Type)]()
@@ -77,7 +40,7 @@ final class LuminaObjectRecognizer: NSObject {
                     recognitionGroup.leave()
                 } else if let results = request.results {
                     let mappedResults = self.mapResults(results)
-                    recognitionResults.append((mappedResults, model.self))
+                    recognitionResults.append((mappedResults, type(of: model)))
                     recognitionGroup.leave()
                 }
             }

--- a/Lumina/Lumina/Camera/LuminaObjectRecognizer.swift
+++ b/Lumina/Lumina/Camera/LuminaObjectRecognizer.swift
@@ -25,7 +25,7 @@ final class LuminaObjectRecognizer: NSObject {
     init(models: [MLModel]) {
         self.models = models
     }
-    
+
     func recognize(from image: UIImage, completion: @escaping ([([LuminaPrediction]?, MLModel.Type)]) -> Void) {
         var recognitionResults = [([LuminaPrediction]?, MLModel.Type)]()
         let recognitionGroup = DispatchGroup()
@@ -59,31 +59,6 @@ final class LuminaObjectRecognizer: NSObject {
             completion(recognitionResults)
         }
     }
-    
-//    func recognize(from image: UIImage, completion: @escaping (_ predictions: [LuminaPrediction]?) -> Void) {
-//
-//        guard let visionModel = try? VNCoreMLModel(for: self.model) else {
-//            completion(nil)
-//            return
-//        }
-//        let request = VNCoreMLRequest(model: visionModel) { request, error in
-//            if error != nil || request.results == nil {
-//                completion(nil)
-//            } else if let results = request.results {
-//                completion(self.mapResults(results))
-//            }
-//        }
-//        guard let coreImage = image.cgImage else {
-//            completion(nil)
-//            return
-//        }
-//        let handler = VNImageRequestHandler(cgImage: coreImage)
-//        do {
-//            try handler.perform([request])
-//        } catch {
-//            completion(nil)
-//        }
-//    }
 
     private func mapResults(_ objects: [Any]) -> [LuminaPrediction] {
         var results = [LuminaPrediction]()

--- a/Lumina/Lumina/Camera/LuminaObjectRecognizer.swift
+++ b/Lumina/Lumina/Camera/LuminaObjectRecognizer.swift
@@ -37,6 +37,7 @@ final class LuminaObjectRecognizer: NSObject {
             }
             let request = VNCoreMLRequest(model: visionModel) { request, error in
                 if error != nil || request.results == nil {
+                    recognitionResults.append((nil, modelPair.1))
                     recognitionGroup.leave()
                 } else if let results = request.results {
                     let mappedResults = self.mapResults(results)

--- a/Lumina/Lumina/UI/Extensions/Delegates/LuminaCameraDelegateExtension.swift
+++ b/Lumina/Lumina/UI/Extensions/Delegates/LuminaCameraDelegateExtension.swift
@@ -11,7 +11,7 @@ import CoreML
 
 extension LuminaViewController: LuminaCameraDelegate {
     @available (iOS 11.0, *)
-    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, MLModel.Type)]?) {
+    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, String)]?) {
         delegate?.streamed(videoFrame: frame, with: predictedObjects, from: self)
     }
 

--- a/Lumina/Lumina/UI/Extensions/Delegates/LuminaCameraDelegateExtension.swift
+++ b/Lumina/Lumina/UI/Extensions/Delegates/LuminaCameraDelegateExtension.swift
@@ -10,7 +10,6 @@ import Foundation
 import CoreML
 
 extension LuminaViewController: LuminaCameraDelegate {
-    @available (iOS 11.0, *)
     func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, Any.Type)]?) {
         delegate?.streamed(videoFrame: frame, with: predictedObjects, from: self)
     }

--- a/Lumina/Lumina/UI/Extensions/Delegates/LuminaCameraDelegateExtension.swift
+++ b/Lumina/Lumina/UI/Extensions/Delegates/LuminaCameraDelegateExtension.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreML
 
 extension LuminaViewController: LuminaCameraDelegate {
     func videoRecordingCaptured(camera: LuminaCamera, videoURL: URL) {
@@ -15,6 +16,11 @@ extension LuminaViewController: LuminaCameraDelegate {
 
     func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [LuminaPrediction]?) {
         delegate?.streamed(videoFrame: frame, with: predictedObjects, from: self)
+    }
+    
+    @available (iOS 11.0, *)
+    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, MLModel.Type)]) {
+        
     }
 
     func finishedFocus(camera: LuminaCamera) {

--- a/Lumina/Lumina/UI/Extensions/Delegates/LuminaCameraDelegateExtension.swift
+++ b/Lumina/Lumina/UI/Extensions/Delegates/LuminaCameraDelegateExtension.swift
@@ -10,17 +10,17 @@ import Foundation
 import CoreML
 
 extension LuminaViewController: LuminaCameraDelegate {
+    @available (iOS 11.0, *)
+    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, MLModel.Type)]?) {
+        delegate?.streamed(videoFrame: frame, with: predictedObjects, from: self)
+    }
+
     func videoRecordingCaptured(camera: LuminaCamera, videoURL: URL) {
         delegate?.captured(videoAt: videoURL, from: self)
     }
 
     func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [LuminaPrediction]?) {
         delegate?.streamed(videoFrame: frame, with: predictedObjects, from: self)
-    }
-    
-    @available (iOS 11.0, *)
-    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, MLModel.Type)]) {
-        
     }
 
     func finishedFocus(camera: LuminaCamera) {

--- a/Lumina/Lumina/UI/Extensions/Delegates/LuminaCameraDelegateExtension.swift
+++ b/Lumina/Lumina/UI/Extensions/Delegates/LuminaCameraDelegateExtension.swift
@@ -11,7 +11,7 @@ import CoreML
 
 extension LuminaViewController: LuminaCameraDelegate {
     @available (iOS 11.0, *)
-    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, String)]?) {
+    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, Any.Type)]?) {
         delegate?.streamed(videoFrame: frame, with: predictedObjects, from: self)
     }
 

--- a/Lumina/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
+++ b/Lumina/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
@@ -47,7 +47,7 @@ public protocol LuminaDelegate: class {
     func streamed(videoFrame: UIImage, with predictions: [LuminaPrediction]?, from controller: LuminaViewController)
     
     @available(iOS 11.0, *)
-    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, type(of: MLModel))]?, from controller: LuminaViewController)
+    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, MLModel.Type)]?, from controller: LuminaViewController)
 
     /// Triggered whenever streamDepthData is set to true on Lumina, and streams depth data detected in the form of AVDepthData
     ///

--- a/Lumina/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
+++ b/Lumina/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
@@ -44,7 +44,6 @@ public protocol LuminaDelegate: class {
     ///   - videoFrame: the frame captured by Lumina
     ///   - predictions: an array of tuples, each containing the predictions made by a model used with Lumina, and its type, for matching against when parsing results.
     ///   - controller: the instance of Lumina that is streaming the frames
-    @available(iOS 11.0, *)
     func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, Any.Type)]?, from controller: LuminaViewController)
 
     /// Triggered whenever streamDepthData is set to true on Lumina, and streams depth data detected in the form of AVDepthData

--- a/Lumina/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
+++ b/Lumina/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
@@ -36,18 +36,16 @@ public protocol LuminaDelegate: class {
     ///   - controller: the instance of Lumina that is streaming the frames
     func streamed(videoFrame: UIImage, from controller: LuminaViewController)
 
-    /// Triggered whenever a CoreML model is given to Lumina, and Lumina streams a video frame alongside a prediction
+    /// Triggered whenever a collection of CoreML models is given to Lumina, and Lumina streams a video frame alongside a collection of predictions
     ///
     /// - Note: Will not be triggered unless streamingModel resolves to not nil. Leaving the streamingModel parameter unset will not trigger this method
     /// - Warning: The other method for passing video frames back via a delegate will not be triggered in the presence of a CoreML model
     /// - Parameters:
     ///   - videoFrame: the frame captured by Lumina
-    ///   - predictions: the predictions made by the model used with Lumina
+    ///   - predictions: an array of tuples, each containing the predictions made by a model used with Lumina, and its type, for matching against when parsing results.
     ///   - controller: the instance of Lumina that is streaming the frames
-    func streamed(videoFrame: UIImage, with predictions: [LuminaPrediction]?, from controller: LuminaViewController)
-    
     @available(iOS 11.0, *)
-    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, String)]?, from controller: LuminaViewController)
+    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, Any.Type)]?, from controller: LuminaViewController)
 
     /// Triggered whenever streamDepthData is set to true on Lumina, and streams depth data detected in the form of AVDepthData
     ///

--- a/Lumina/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
+++ b/Lumina/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
@@ -47,7 +47,7 @@ public protocol LuminaDelegate: class {
     func streamed(videoFrame: UIImage, with predictions: [LuminaPrediction]?, from controller: LuminaViewController)
     
     @available(iOS 11.0, *)
-    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, MLModel.Type)]?, from controller: LuminaViewController)
+    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, String)]?, from controller: LuminaViewController)
 
     /// Triggered whenever streamDepthData is set to true on Lumina, and streams depth data detected in the form of AVDepthData
     ///

--- a/Lumina/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
+++ b/Lumina/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import CoreML
 
 /// Delegate for returning information to the application utilizing Lumina
 public protocol LuminaDelegate: class {
@@ -44,6 +45,9 @@ public protocol LuminaDelegate: class {
     ///   - predictions: the predictions made by the model used with Lumina
     ///   - controller: the instance of Lumina that is streaming the frames
     func streamed(videoFrame: UIImage, with predictions: [LuminaPrediction]?, from controller: LuminaViewController)
+    
+    @available(iOS 11.0, *)
+    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, type(of: MLModel))]?, from controller: LuminaViewController)
 
     /// Triggered whenever streamDepthData is set to true on Lumina, and streams depth data detected in the form of AVDepthData
     ///

--- a/Lumina/Lumina/UI/LuminaViewController.swift
+++ b/Lumina/Lumina/UI/LuminaViewController.swift
@@ -193,18 +193,13 @@ public final class LuminaViewController: UIViewController {
         }
     }
 
-    private var _streamingModels: [(AnyObject, String)]?
+    private var _streamingModels: [(AnyObject, Any.Type)]?
 
-    /// A collection of models that will be used when streaming images for object recognition
-    ///
-    /// - Note: Only works on iOS 11 and up
-    ///
-    /// - Warning: If this is set, streamFrames is over-ridden to true
     @available(iOS 11.0, *)
-    var streamingModels: [(MLModel, String)]? {
+    var streamingModels: [(MLModel, Any.Type)]? {
         get {
             if let existingModels = _streamingModels {
-                var models = [(MLModel, String)]()
+                var models = [(MLModel, Any.Type)]()
                 for potentialModel in existingModels {
                     if let model = potentialModel.0 as? MLModel {
                         models.append((model, potentialModel.1))
@@ -220,7 +215,7 @@ public final class LuminaViewController: UIViewController {
         }
         set {
             if let tuples = newValue {
-                var downcastCollection = [(AnyObject, String)]()
+                var downcastCollection = [(AnyObject, Any.Type)]()
                 for tuple in tuples {
                     downcastCollection.append((tuple.0 as AnyObject, tuple.1))
                 }
@@ -231,30 +226,30 @@ public final class LuminaViewController: UIViewController {
         }
     }
 
+    /// A collection of model types that will be used when streaming images for object recognition
+    ///
+    /// - Note: Only works on iOS 11 and up
+    ///
+    /// - Warning: If this is set, streamFrames is over-ridden to true
     open var streamingModelTypes: [AnyObject]? {
         didSet {
             if #available(iOS 11.0, *) {
-                var modelsToSet = [(MLModel, String)]()
-                var newModelsToSet = [(MLModel, Any.Type)]()
-                if let types = streamingModelTypes {
-                    for type in types {
-                        let reflection = Mirror(reflecting: type)
-                        for (name, value) in reflection.children where name == "model" {
-                            guard let className = String(describing: type.self).components(separatedBy: ".").last else {
-                                continue
-                            }
-                            guard let model = value as? MLModel else {
-                                continue
-                            }
-                            modelsToSet.append((model, className))
-                            print(reflection.subjectType)
-                            newModelsToSet.append((model, reflection.subjectType))
-                        }
-                    }
-                    self.streamingModels = modelsToSet
+                var modelsToSet = [(MLModel, Any.Type)]()
+                guard let types = streamingModelTypes else {
+                    return
                 }
+                for type in types {
+                    let reflection = Mirror(reflecting: type)
+                    for (name, value) in reflection.children where name == "model" {
+                        guard let model = value as? MLModel else {
+                            continue
+                        }
+                        modelsToSet.append((model, reflection.subjectType))
+                    }
+                }
+                self.streamingModels = modelsToSet
             } else {
-                print("Muse be using iOS 11.0 or higher for CoreML")
+                print("Must be using iOS 11.0 or higher for CoreML")
             }
         }
     }

--- a/Lumina/Lumina/UI/LuminaViewController.swift
+++ b/Lumina/Lumina/UI/LuminaViewController.swift
@@ -193,7 +193,7 @@ public final class LuminaViewController: UIViewController {
         }
     }
 
-    private var _streamingModel: AnyObject?
+    private var _streamingModels: [AnyObject]?
 
     /// A model that will be used when streaming images for object recognition
     ///
@@ -201,15 +201,28 @@ public final class LuminaViewController: UIViewController {
     ///
     /// - Warning: If this is set, streamFrames is over-ridden to true
     @available(iOS 11.0, *)
-    open var streamingModel: MLModel? {
+    open var streamingModels: [MLModel]? {
         get {
-            return _streamingModel as? MLModel
+            if let existingModels = _streamingModels {
+                var models = [MLModel]()
+                for potentialModel in existingModels {
+                    if let model = potentialModel as? MLModel {
+                        models.append(model)
+                    }
+                }
+                guard models.count > 0  else {
+                    return nil
+                }
+                return models
+            } else {
+                return nil
+            }
         }
         set {
             if newValue != nil {
-                _streamingModel = newValue
+                _streamingModels = newValue
                 self.streamFrames = true
-                self.camera?.streamingModel = newValue
+                self.camera?.streamingModels = newValue
             }
         }
     }

--- a/Lumina/Lumina/Util/Info.plist
+++ b/Lumina/Lumina/Util/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.0</string>
+	<string>0.13.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/LuminaSample/LuminaSample.xcodeproj/project.pbxproj
+++ b/LuminaSample/LuminaSample.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		534C1E9E1F7C3C59001127BC /* ResolutionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534C1E9D1F7C3C59001127BC /* ResolutionViewController.swift */; };
 		5365BFD41F79829800B8F338 /* ImageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5365BFD31F79829800B8F338 /* ImageViewController.swift */; };
 		5365BFDA1F79AAA800B8F338 /* MobileNet.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = 5365BFD91F79AA9B00B8F338 /* MobileNet.mlmodel */; };
+		5373B3F11FC61BBF00C197BD /* SqueezeNet.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = 5373B3F01FC61BBF00C197BD /* SqueezeNet.mlmodel */; };
 		53B828F71EAAA09000E3A624 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B828F61EAAA09000E3A624 /* AppDelegate.swift */; };
 		53B828F91EAAA09000E3A624 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53B828F81EAAA09000E3A624 /* ViewController.swift */; };
 		53B828FC1EAAA09000E3A624 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 53B828FA1EAAA09000E3A624 /* Main.storyboard */; };
@@ -37,6 +38,7 @@
 		534C1E9D1F7C3C59001127BC /* ResolutionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolutionViewController.swift; sourceTree = "<group>"; };
 		5365BFD31F79829800B8F338 /* ImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewController.swift; sourceTree = "<group>"; };
 		5365BFD91F79AA9B00B8F338 /* MobileNet.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; name = MobileNet.mlmodel; path = LuminaSample/MobileNet.mlmodel; sourceTree = "<group>"; };
+		5373B3F01FC61BBF00C197BD /* SqueezeNet.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; name = SqueezeNet.mlmodel; path = LuminaSample/SqueezeNet.mlmodel; sourceTree = "<group>"; };
 		53B828F31EAAA09000E3A624 /* LuminaSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LuminaSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		53B828F61EAAA09000E3A624 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		53B828F81EAAA09000E3A624 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -96,6 +98,7 @@
 			children = (
 				53F55EDF1FABE1FA00299980 /* Lumina.framework */,
 				5365BFD91F79AA9B00B8F338 /* MobileNet.mlmodel */,
+				5373B3F01FC61BBF00C197BD /* SqueezeNet.mlmodel */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -176,6 +179,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				534C1E9E1F7C3C59001127BC /* ResolutionViewController.swift in Sources */,
+				5373B3F11FC61BBF00C197BD /* SqueezeNet.mlmodel in Sources */,
 				5365BFDA1F79AAA800B8F338 /* MobileNet.mlmodel in Sources */,
 				53B828F91EAAA09000E3A624 /* ViewController.swift in Sources */,
 				5365BFD41F79829800B8F338 /* ImageViewController.swift in Sources */,

--- a/LuminaSample/LuminaSample/Base.lproj/Main.storyboard
+++ b/LuminaSample/LuminaSample/Base.lproj/Main.storyboard
@@ -424,7 +424,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="71.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Use CoreML Model" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KUt-sS-9wk">
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Use CoreML" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KUt-sS-9wk">
                                                     <rect key="frame" x="8" y="28" width="302" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="21" id="ff0-67-L7O"/>

--- a/LuminaSample/LuminaSample/Info.plist
+++ b/LuminaSample/LuminaSample/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.0</string>
+	<string>0.13.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/LuminaSample/LuminaSample/ViewController.swift
+++ b/LuminaSample/LuminaSample/ViewController.swift
@@ -58,7 +58,7 @@ extension ViewController { //MARK: IBActions
         camera.maxZoomScale = (self.maxZoomScaleLabel.text! as NSString).floatValue
         camera.frameRate = Int(self.frameRateLabel.text!) ?? 30
         if #available(iOS 11.0, *) {
-            camera.streamingModels = self.useCoreMLModelSwitch.isOn ? [MobileNet().model, SqueezeNet().model] : nil
+            camera.streamingModelTypes = self.useCoreMLModelSwitch.isOn ? [MobileNet(), SqueezeNet()] : nil
         }
         present(camera, animated: true, completion: nil)
     }
@@ -92,23 +92,41 @@ extension ViewController { //MARK: IBActions
 
 extension ViewController: LuminaDelegate {
     @available (iOS 11.0, *)
-    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, MLModel.Type)]?, from controller: LuminaViewController) {
+    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, String)]?, from controller: LuminaViewController) {
         guard let predicted = predictions else {
             return
         }
         for prediction in predicted {
-            print(type(of: prediction.1))
-            if prediction.1 == type(of: MobileNet.self) {
+            if prediction.1 == "MobileNet" {
                 guard let values = prediction.0 else {
                     return
                 }
                 guard let bestPrediction = values.first else {
                     return
                 }
-                controller.textPrompt = "Object: \(bestPrediction.name), Confidence: \(bestPrediction.confidence * 100)%, Model: \(type(of: prediction.1))"
+                controller.textPrompt = "Object: \(bestPrediction.name), Confidence: \(bestPrediction.confidence * 100)%, Model: \(prediction.1)"
             }
         }
     }
+    
+//
+//    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, MLModel.Type)]?, from controller: LuminaViewController) {
+//        guard let predicted = predictions else {
+//            return
+//        }
+//        for prediction in predicted {
+//            print(type(of: prediction.1))
+//            if prediction.1 == type(of: MobileNet.self) {
+//                guard let values = prediction.0 else {
+//                    return
+//                }
+//                guard let bestPrediction = values.first else {
+//                    return
+//                }
+//                controller.textPrompt = "Object: \(bestPrediction.name), Confidence: \(bestPrediction.confidence * 100)%, Model: \(type(of: prediction.1))"
+//            }
+//        }
+//    }
     
     func captured(stillImage: UIImage, livePhotoAt: URL?, depthData: Any?, from controller: LuminaViewController) {
         controller.dismiss(animated: true) {

--- a/LuminaSample/LuminaSample/ViewController.swift
+++ b/LuminaSample/LuminaSample/ViewController.swift
@@ -92,19 +92,19 @@ extension ViewController { //MARK: IBActions
 
 extension ViewController: LuminaDelegate {
     @available (iOS 11.0, *)
-    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, String)]?, from controller: LuminaViewController) {
+    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, Any.Type)]?, from controller: LuminaViewController) {
         guard let predicted = predictions else {
             return
         }
         for prediction in predicted {
-            if prediction.1 == "MobileNet" {
+            if prediction.1 == SqueezeNet.self {
                 guard let values = prediction.0 else {
                     return
                 }
                 guard let bestPrediction = values.first else {
                     return
                 }
-                controller.textPrompt = "Object: \(bestPrediction.name), Confidence: \(bestPrediction.confidence * 100)%, Model: \(prediction.1)"
+                controller.textPrompt = "Object: \(bestPrediction.name), Confidence: \(bestPrediction.confidence * 100)%, Model: \(String(describing: prediction.1))"
             }
         }
     }

--- a/LuminaSample/LuminaSample/ViewController.swift
+++ b/LuminaSample/LuminaSample/ViewController.swift
@@ -97,10 +97,15 @@ extension ViewController: LuminaDelegate {
             return
         }
         for prediction in predicted {
+            print(type(of: prediction.1))
             if prediction.1 == type(of: MobileNet.self) {
                 guard let values = prediction.0 else {
-                    continue
+                    return
                 }
+                guard let bestPrediction = values.first else {
+                    return
+                }
+                controller.textPrompt = "Object: \(bestPrediction.name), Confidence: \(bestPrediction.confidence * 100)%, Model: \(type(of: prediction.1))"
             }
         }
     }

--- a/LuminaSample/LuminaSample/ViewController.swift
+++ b/LuminaSample/LuminaSample/ViewController.swift
@@ -58,7 +58,7 @@ extension ViewController { //MARK: IBActions
         camera.maxZoomScale = (self.maxZoomScaleLabel.text! as NSString).floatValue
         camera.frameRate = Int(self.frameRateLabel.text!) ?? 30
         if #available(iOS 11.0, *) {
-            camera.streamingModels = self.useCoreMLModelSwitch.isOn ? [MobileNet().model] : nil
+            camera.streamingModels = self.useCoreMLModelSwitch.isOn ? [MobileNet().model, SqueezeNet().model] : nil
         }
         present(camera, animated: true, completion: nil)
     }
@@ -91,6 +91,20 @@ extension ViewController { //MARK: IBActions
 }
 
 extension ViewController: LuminaDelegate {
+    @available (iOS 11.0, *)
+    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, MLModel.Type)]?, from controller: LuminaViewController) {
+        guard let predicted = predictions else {
+            return
+        }
+        for prediction in predicted {
+            if prediction.1 == type(of: MobileNet.self) {
+                guard let values = prediction.0 else {
+                    continue
+                }
+            }
+        }
+    }
+    
     func captured(stillImage: UIImage, livePhotoAt: URL?, depthData: Any?, from controller: LuminaViewController) {
         controller.dismiss(animated: true) {
             self.performSegue(withIdentifier: "stillImageOutputSegue", sender: ["stillImage" : stillImage, "livePhotoURL" : livePhotoAt as Any, "depthData" : depthData, "isPhotoSelfie" : controller.position == .front ? true : false])
@@ -108,15 +122,17 @@ extension ViewController: LuminaDelegate {
         }
     }
     
-    func streamed(videoFrame: UIImage, with predictions: [LuminaPrediction]?, from controller: LuminaViewController) {
-        guard let predicted = predictions else {
-            return
-        }
-        guard let bestPrediction = predicted.first else {
-            return
-        }
-        controller.textPrompt = "Object: \(bestPrediction.name), Confidence: \(bestPrediction.confidence * 100)%"
-    }
+//
+//
+//    func streamed(videoFrame: UIImage, with predictions: [LuminaPrediction]?, from controller: LuminaViewController) {
+//        guard let predicted = predictions else {
+//            return
+//        }
+//        guard let bestPrediction = predicted.first else {
+//            return
+//        }
+//        controller.textPrompt = "Object: \(bestPrediction.name), Confidence: \(bestPrediction.confidence * 100)%"
+//    }
     
     func detected(metadata: [Any], from controller: LuminaViewController) {
         print(metadata)

--- a/LuminaSample/LuminaSample/ViewController.swift
+++ b/LuminaSample/LuminaSample/ViewController.swift
@@ -58,7 +58,7 @@ extension ViewController { //MARK: IBActions
         camera.maxZoomScale = (self.maxZoomScaleLabel.text! as NSString).floatValue
         camera.frameRate = Int(self.frameRateLabel.text!) ?? 30
         if #available(iOS 11.0, *) {
-            camera.streamingModel = self.useCoreMLModelSwitch.isOn ? MobileNet().model : nil
+            camera.streamingModels = self.useCoreMLModelSwitch.isOn ? [MobileNet().model] : nil
         }
         present(camera, animated: true, completion: nil)
     }

--- a/README.md
+++ b/README.md
@@ -160,12 +160,12 @@ camera.maxZoomScale = 5.0 // not setting this defaults to the highest zoom scale
 
 **NB:** This only works for iOS 11.0 and up.
 
-You must have a `CoreML` compatible model to try this. Ensure that you drag the model file into your project file, and add it to your current application target.
+You must have a `CoreML` compatible model(s) to try this. Ensure that you drag the model file(s) into your project file, and add it to your current application target.
 
-The sample in this repository comes with the `MobileNet` image recognition model, but again, any `CoreML` compatible model will work with this framework. Assign your model to the framework like so:
+The sample in this repository comes with the `MobileNet` and `SqueezeNet` image recognition models, but again, any `CoreML` compatible model will work with this framework. Assign your model(s) to the framework like so:
 
 ```swift
-camera.streamingModel = MobileNet().model
+camera.streamingModelTypes = [MobileNet(), SqueezeNet()]
 ```
 
 You are now set up to perform live video object recognition.
@@ -234,20 +234,30 @@ func detected(metadata: [Any], from controller: LuminaViewController) {
 ```
 
 To handle a `CoreML` model and its predictions being streamed with each video frame, implement:
-
 ```swift
-func streamed(videoFrame: UIImage, with predictions: [LuminaPrediction]?, from controller: LuminaViewController) {
+func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, Any.Type)]?, from controller: LuminaViewController) {
     guard let predicted = predictions else {
         return
     }
-    guard let bestPrediction = predicted.first else {
-        return
+    for prediction in predicted {
+        if #available(iOS 11.0, *) {
+            if prediction.1 == MobileNet.self {
+                guard let values = prediction.0 else {
+                    return
+                }
+                guard let bestPrediction = values.first else {
+                    return
+                }
+                controller.textPrompt = "Object: \(bestPrediction.name), Confidence: \(bestPrediction.confidence * 100)%, Model: \(String(describing: prediction.1))"
+            }
+        } else {
+            print("CoreML not available in iOS 10.0")
+        }
     }
-    controller.textPrompt = "Object: \(bestPrediction.name), Confidence: \(bestPrediction.confidence * 100)%"
-    }
+}
 ```
 
-The example above also makes use of the built-in text prompt mechanism for Lumina.
+Note that this returns a class type representation associated with the detected results. The example above also makes use of the built-in text prompt mechanism for Lumina.
 
 ## Maintainers
 


### PR DESCRIPTION
Fixes #39 

Now, model assignment is even simpler at the interface:

```swift 
camera.streamingModelTypes = [MobileNet(), SqueezeNet()]
```

Lumina will handle everything under the hood, and the delegate function has changed to:
```swift
func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, Any.Type)]?, from controller: LuminaViewController)
```