### PR TITLE
Refactored model allocation

### DIFF
--- a/Lumina.podspec
+++ b/Lumina.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name        = "Lumina"
-  s.version     = "0.13.1"
+  s.version     = "0.13.2"
   s.summary     = "Lumina gives you a camera for most photo processing needs, including streaming frames for CoreML live detection."
   s.homepage    = "https://github.com/dokun1/Lumina"
   s.license     = { :type => "MIT" }

--- a/Lumina/Lumina/UI/LuminaViewController.swift
+++ b/Lumina/Lumina/UI/LuminaViewController.swift
@@ -193,39 +193,6 @@ public final class LuminaViewController: UIViewController {
         }
     }
 
-    private var _streamingModels: [(AnyObject, Any.Type)]?
-
-    @available(iOS 11.0, *)
-    var streamingModels: [(MLModel, Any.Type)]? {
-        get {
-            if let existingModels = _streamingModels {
-                var models = [(MLModel, Any.Type)]()
-                for potentialModel in existingModels {
-                    if let model = potentialModel.0 as? MLModel {
-                        models.append((model, potentialModel.1))
-                    }
-                }
-                guard models.count > 0  else {
-                    return nil
-                }
-                return models
-            } else {
-                return nil
-            }
-        }
-        set {
-            if let tuples = newValue {
-                var downcastCollection = [(AnyObject, Any.Type)]()
-                for tuple in tuples {
-                    downcastCollection.append((tuple.0 as AnyObject, tuple.1))
-                }
-                _streamingModels = downcastCollection
-                self.streamFrames = true
-                self.camera?.streamingModels = tuples
-            }
-        }
-    }
-
     /// A collection of model types that will be used when streaming images for object recognition
     ///
     /// - Note: Only works on iOS 11 and up
@@ -247,7 +214,10 @@ public final class LuminaViewController: UIViewController {
                         modelsToSet.append((model, reflection.subjectType))
                     }
                 }
-                self.streamingModels = modelsToSet
+                if modelsToSet.count > 0 {
+                    self.streamFrames = true
+                    self.camera?.streamingModels = modelsToSet
+                }
             } else {
                 print("Must be using iOS 11.0 or higher for CoreML")
             }

--- a/Lumina/Lumina/Util/Info.plist
+++ b/Lumina/Lumina/Util/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.1</string>
+	<string>0.13.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/LuminaSample/LuminaSample/Info.plist
+++ b/LuminaSample/LuminaSample/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.13.1</string>
+	<string>0.13.2</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Before, I was getting the model out of the classes passed into `LuminaViewController`, passing it to a local object in the view controller, and being repetitive. Now, I let `LuminaCamera` do the work, and `LuminaViewController` is much smaller now.