### PR TITLE
Use safe area guides for text label and shutter button

### DIFF
--- a/Lumina/Lumina/UI/Extensions/InterfaceHandlerExtension.swift
+++ b/Lumina/Lumina/UI/Extensions/InterfaceHandlerExtension.swift
@@ -58,8 +58,18 @@ extension LuminaViewController {
     func updateButtonFrames() {
         self.cancelButton.center = CGPoint(x: self.view.frame.minX + 55, y: self.view.frame.maxY - 45)
         if self.view.frame.width > self.view.frame.height {
-            self.shutterButton.center = CGPoint(x: self.view.frame.maxX - 45, y: self.view.frame.midY)
+            var maxX = self.view.frame.maxX
+            if #available(iOS 11, *) {
+                maxX = self.view.safeAreaLayoutGuide.layoutFrame.maxX
+            }
+            maxX = maxX - 45
+            self.shutterButton.center = CGPoint(x: maxX, y: self.view.frame.midY)
         } else {
+            var maxY = self.view.frame.maxY
+            if #available(iOS 11, *) {
+                maxY = self.view.safeAreaLayoutGuide.layoutFrame.maxY
+            }
+            maxY = maxY - 45
             self.shutterButton.center = CGPoint(x: self.view.frame.midX, y: self.view.frame.maxY - 45)
         }
         self.switchButton.center = CGPoint(x: self.view.frame.maxX - 25, y: self.view.frame.minY + 25)

--- a/Lumina/Lumina/UI/Extensions/InterfaceHandlerExtension.swift
+++ b/Lumina/Lumina/UI/Extensions/InterfaceHandlerExtension.swift
@@ -57,25 +57,28 @@ extension LuminaViewController {
 
     func updateButtonFrames() {
         self.cancelButton.center = CGPoint(x: self.view.frame.minX + 55, y: self.view.frame.maxY - 45)
+        var minY = self.view.frame.minY
         if self.view.frame.width > self.view.frame.height {
             var maxX = self.view.frame.maxX
             if #available(iOS 11, *) {
                 maxX = self.view.safeAreaLayoutGuide.layoutFrame.maxX
             }
-            maxX -= 45
-            self.shutterButton.center = CGPoint(x: maxX, y: self.view.frame.midY)
+            self.shutterButton.center = CGPoint(x: maxX - 45, y: self.view.frame.midY)
         } else {
             var maxY = self.view.frame.maxY
             if #available(iOS 11, *) {
                 maxY = self.view.safeAreaLayoutGuide.layoutFrame.maxY
+                minY = self.view.safeAreaLayoutGuide.layoutFrame.minY
             }
-            maxY -= 45
-            self.shutterButton.center = CGPoint(x: self.view.frame.midX, y: self.view.frame.maxY - 45)
+            self.shutterButton.center = CGPoint(x: self.view.frame.midX, y: maxY - 45)
         }
         self.switchButton.center = CGPoint(x: self.view.frame.maxX - 25, y: self.view.frame.minY + 25)
         self.torchButton.center = CGPoint(x: self.view.frame.minX + 25, y: self.view.frame.minY + 25)
+        /// Use more width, if text has been moved down below the buttons (e.g. notch on iPhone X):
+        let textWidth = self.view.frame.maxX - (minY > 35 ? 20 : 110)
+        self.textPromptView.frame.size = CGSize(width: textWidth, height: 80)
         self.textPromptView.layoutSubviews()
-        self.textPromptView.center = CGPoint(x: self.view.frame.midX, y: self.view.frame.minY + 45)
+        self.textPromptView.center = CGPoint(x: self.view.frame.midX, y: minY + 45)
     }
 
     // swiftlint:disable cyclomatic_complexity

--- a/Lumina/Lumina/UI/Extensions/InterfaceHandlerExtension.swift
+++ b/Lumina/Lumina/UI/Extensions/InterfaceHandlerExtension.swift
@@ -62,14 +62,14 @@ extension LuminaViewController {
             if #available(iOS 11, *) {
                 maxX = self.view.safeAreaLayoutGuide.layoutFrame.maxX
             }
-            maxX = maxX - 45
+            maxX -= 45
             self.shutterButton.center = CGPoint(x: maxX, y: self.view.frame.midY)
         } else {
             var maxY = self.view.frame.maxY
             if #available(iOS 11, *) {
                 maxY = self.view.safeAreaLayoutGuide.layoutFrame.maxY
             }
-            maxY = maxY - 45
+            maxY -= 45
             self.shutterButton.center = CGPoint(x: self.view.frame.midX, y: self.view.frame.maxY - 45)
         }
         self.switchButton.center = CGPoint(x: self.view.frame.maxX - 25, y: self.view.frame.minY + 25)

--- a/Lumina/Lumina/UI/LuminaButton.swift
+++ b/Lumina/Lumina/UI/LuminaButton.swift
@@ -89,7 +89,12 @@ final class LuminaButton: UIButton {
             self.titleLabel?.layer.shadowRadius = 6
         case .shutter:
             self.backgroundColor = UIColor.normalState
-            self.frame = CGRect(origin: CGPoint(x: UIScreen.main.bounds.midX - 35, y: UIScreen.main.bounds.maxY - 80), size: CGSize(width: self.shutterButtonDimension, height: self.shutterButtonDimension))
+            var minY = UIScreen.main.bounds.maxY
+            if #available(iOS 11, *) {
+                minY = self.safeAreaLayoutGuide.layoutFrame.maxY
+            }
+            minY = minY - 80
+            self.frame = CGRect(origin: CGPoint(x: UIScreen.main.bounds.midX - 35, y: minY), size: CGSize(width: self.shutterButtonDimension, height: self.shutterButtonDimension))
             self.layer.cornerRadius = CGFloat(self.shutterButtonDimension / 2)
             self.layer.borderWidth = 3
             self.layer.borderColor = UIColor.borderNormalState

--- a/Lumina/Lumina/UI/LuminaButton.swift
+++ b/Lumina/Lumina/UI/LuminaButton.swift
@@ -93,7 +93,7 @@ final class LuminaButton: UIButton {
             if #available(iOS 11, *) {
                 minY = self.safeAreaLayoutGuide.layoutFrame.maxY
             }
-            minY = minY - 80
+            minY -=  80
             self.frame = CGRect(origin: CGPoint(x: UIScreen.main.bounds.midX - 35, y: minY), size: CGSize(width: self.shutterButtonDimension, height: self.shutterButtonDimension))
             self.layer.cornerRadius = CGFloat(self.shutterButtonDimension / 2)
             self.layer.borderWidth = 3

--- a/Lumina/Lumina/UI/LuminaTextPromptView.swift
+++ b/Lumina/Lumina/UI/LuminaTextPromptView.swift
@@ -64,13 +64,7 @@ final class LuminaTextPromptView: UIView {
     }
 
     override func layoutSubviews() {
-        self.frame.size = CGSize(width: UIScreen.main.bounds.maxX - 110, height: 80)
-        var minY = CGFloat(0.0)
-        if #available(iOS 11, *) {
-            minY = self.safeAreaLayoutGuide.layoutFrame.minY
-        }
-        minY += 5.0
-        self.textLabel.frame = CGRect(origin: CGPoint(x: 5, y: minY), size: CGSize(width: frame.width - 10, height: frame.height - 10))
+        self.textLabel.frame = CGRect(origin: CGPoint(x: 5, y: 5), size: CGSize(width: frame.width - 10, height: frame.height - 10))
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Lumina/Lumina/UI/LuminaTextPromptView.swift
+++ b/Lumina/Lumina/UI/LuminaTextPromptView.swift
@@ -65,7 +65,12 @@ final class LuminaTextPromptView: UIView {
 
     override func layoutSubviews() {
         self.frame.size = CGSize(width: UIScreen.main.bounds.maxX - 110, height: 80)
-        self.textLabel.frame = CGRect(origin: CGPoint(x: 5, y: 5), size: CGSize(width: frame.width - 10, height: frame.height - 10))
+        var minY = CGFloat(0.0)
+        if #available(iOS 11, *) {
+            minY = self.safeAreaLayoutGuide.layoutFrame.minY
+        }
+        minY = minY + 5.0
+        self.textLabel.frame = CGRect(origin: CGPoint(x: 5, y: minY), size: CGSize(width: frame.width - 10, height: frame.height - 10))
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/Lumina/Lumina/UI/LuminaTextPromptView.swift
+++ b/Lumina/Lumina/UI/LuminaTextPromptView.swift
@@ -69,7 +69,7 @@ final class LuminaTextPromptView: UIView {
         if #available(iOS 11, *) {
             minY = self.safeAreaLayoutGuide.layoutFrame.minY
         }
-        minY = minY + 5.0
+        minY += 5.0
         self.textLabel.frame = CGRect(origin: CGPoint(x: 5, y: minY), size: CGSize(width: frame.width - 10, height: frame.height - 10))
     }
 


### PR DESCRIPTION
To improve the layout especially on iPhoneX, the safe area guides are used for 
- text label - might be partially occluded by the notch
- shutter button - might be too close to the border