### PR TITLE
Updated result from CoreML to be a struct and not a tuple

### DIFF
--- a/Lumina/Lumina/Camera/LuminaCamera.swift
+++ b/Lumina/Lumina/Camera/LuminaCamera.swift
@@ -14,7 +14,7 @@ protocol LuminaCameraDelegate: class {
     func stillImageCaptured(camera: LuminaCamera, image: UIImage, livePhotoURL: URL?, depthData: Any?)
     func videoFrameCaptured(camera: LuminaCamera, frame: UIImage)
     @available (iOS 11.0, *)
-    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, Any.Type)]?)
+    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [LuminaRecognitionResult]?)
     func depthDataCaptured(camera: LuminaCamera, depthData: Any)
     func videoRecordingCaptured(camera: LuminaCamera, videoURL: URL)
     func finishedFocus(camera: LuminaCamera)

--- a/Lumina/Lumina/Camera/LuminaObjectRecognizer.swift
+++ b/Lumina/Lumina/Camera/LuminaObjectRecognizer.swift
@@ -16,6 +16,16 @@ public struct LuminaPrediction {
     public var name: String
     /// The numeric value of the confidence of the prediction, out of 1.0
     public var confidence: Float
+    /// The unique identifier associated with this prediction, as determined by the Vision framework
+    public var UUID: UUID
+}
+
+/// An object that represents a collection of predictions that Lumina detects, along with their associated types
+public struct LuminaRecognitionResult {
+    /// The collection of predictions in a given result, as predicted by Lumina
+    public var predictions: [LuminaPrediction]?
+    /// The type of MLModel that made the predictions, best resolved as a String
+    public var type: Any.Type
 }
 
 @available(iOS 11.0, *)
@@ -27,8 +37,12 @@ final class LuminaObjectRecognizer: NSObject {
         self.modelPairs = modelPairs
     }
 
-    func recognize(from image: UIImage, completion: @escaping ([([LuminaPrediction]?, Any.Type)]) -> Void) {
-        var recognitionResults = [([LuminaPrediction]?, Any.Type)]()
+    func recognize(from image: UIImage, completion: @escaping ([LuminaRecognitionResult]?) -> Void) {
+        guard let coreImage = image.cgImage else {
+            completion(nil)
+            return
+        }
+        var recognitionResults = [LuminaRecognitionResult]()
         let recognitionGroup = DispatchGroup()
         for modelPair in modelPairs {
             recognitionGroup.enter()
@@ -38,17 +52,13 @@ final class LuminaObjectRecognizer: NSObject {
             }
             let request = VNCoreMLRequest(model: visionModel) { request, error in
                 if error != nil || request.results == nil {
-                    recognitionResults.append((nil, modelPair.1))
+                    recognitionResults.append(LuminaRecognitionResult(predictions: nil, type: modelPair.1))
                     recognitionGroup.leave()
                 } else if let results = request.results {
                     let mappedResults = self.mapResults(results)
-                    recognitionResults.append((mappedResults, modelPair.1))
+                    recognitionResults.append(LuminaRecognitionResult(predictions: mappedResults, type: modelPair.1))
                     recognitionGroup.leave()
                 }
-            }
-            guard let coreImage = image.cgImage else {
-                recognitionGroup.leave()
-                continue
             }
             let handler = VNImageRequestHandler(cgImage: coreImage)
             do {
@@ -67,7 +77,7 @@ final class LuminaObjectRecognizer: NSObject {
         var results = [LuminaPrediction]()
         for object in objects {
             if let object = object as? VNClassificationObservation {
-                results.append(LuminaPrediction(name: object.identifier, confidence: object.confidence))
+                results.append(LuminaPrediction(name: object.identifier, confidence: object.confidence, UUID: object.uuid))
             }
         }
         return results.sorted(by: {

--- a/Lumina/Lumina/UI/Extensions/Delegates/LuminaCameraDelegateExtension.swift
+++ b/Lumina/Lumina/UI/Extensions/Delegates/LuminaCameraDelegateExtension.swift
@@ -10,6 +10,10 @@ import Foundation
 import CoreML
 
 extension LuminaViewController: LuminaCameraDelegate {
+    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [LuminaRecognitionResult]?) {
+        delegate?.streamed(videoFrame: frame, with: predictedObjects, from: self)
+    }
+
     func videoRecordingCaptured(camera: LuminaCamera, videoURL: URL) {
         delegate?.captured(videoAt: videoURL, from: self)
     }
@@ -27,10 +31,6 @@ extension LuminaViewController: LuminaCameraDelegate {
 
     func videoFrameCaptured(camera: LuminaCamera, frame: UIImage) {
         delegate?.streamed(videoFrame: frame, from: self)
-    }
-
-    func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [([LuminaPrediction]?, Any.Type)]?) {
-        delegate?.streamed(videoFrame: frame, with: predictedObjects, from: self)
     }
 
     func detected(camera: LuminaCamera, metadata: [Any]) {

--- a/Lumina/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
+++ b/Lumina/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
@@ -42,9 +42,9 @@ public protocol LuminaDelegate: class {
     /// - Warning: The other method for passing video frames back via a delegate will not be triggered in the presence of a CoreML model
     /// - Parameters:
     ///   - videoFrame: the frame captured by Lumina
-    ///   - predictions: an array of tuples, each containing the predictions made by a model used with Lumina, and its type, for matching against when parsing results.
+    ///   - predictions: an array of objects typed LuminaRecognitionResult, containing the predictions made by a model used with Lumina, and its type, for matching against when parsing results.
     ///   - controller: the instance of Lumina that is streaming the frames
-    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, Any.Type)]?, from controller: LuminaViewController)
+    func streamed(videoFrame: UIImage, with predictions: [LuminaRecognitionResult]?, from controller: LuminaViewController)
 
     /// Triggered whenever streamDepthData is set to true on Lumina, and streams depth data detected in the form of AVDepthData
     ///

--- a/Lumina/Lumina/Util/Info.plist
+++ b/Lumina/Lumina/Util/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/LuminaSample/LuminaSample/Info.plist
+++ b/LuminaSample/LuminaSample/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/LuminaSample/LuminaSample/ViewController.swift
+++ b/LuminaSample/LuminaSample/ViewController.swift
@@ -98,20 +98,20 @@ extension ViewController { //MARK: IBActions
 }
 
 extension ViewController: LuminaDelegate {
-    func streamed(videoFrame: UIImage, with predictions: [([LuminaPrediction]?, Any.Type)]?, from controller: LuminaViewController) {
+    func streamed(videoFrame: UIImage, with predictions: [LuminaRecognitionResult]?, from controller: LuminaViewController) {
         if #available(iOS 11.0, *) {
             guard let predicted = predictions else {
                 return
             }
             var resultString = String()
             for prediction in predicted {
-                guard let values = prediction.0 else {
+                guard let values = prediction.predictions else {
                     continue
                 }
                 guard let bestPrediction = values.first else {
                     continue
                 }
-                resultString.append("\(String(describing: prediction.1)): \(bestPrediction.name)" + "\r\n")
+                resultString.append("\(String(describing: prediction.type)): \(bestPrediction.name)" + "\r\n")
             }
             controller.textPrompt = resultString
         } else {


### PR DESCRIPTION
This forces the results streamed from Lumina into a handy struct rather than a tuple. The function signature was verbose before:

`func recognize(from image: UIImage, completion: @escaping ([([LuminaPrediction]?, Any.Type)]) -> Void) {`

Now, we make use of a new struct titled `LuminaRecognitionResult`, and the function signature reads like so:

`func recognize(from image: UIImage, completion: @escaping ([LuminaRecognitionResult]?) -> Void) {`

This propagates to the developer interface as well, so this does technically break the high level interface if you were using CoreML, but the change you need to make is trivial. This will also signal the release of v1.1.0