### PR TITLE
Remove unused .gitmodules reference to swift-log

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "swift-log"]
-	path = swift-log
-	url = https://github.com/apple/swift-log.git
-	branch = master


### PR DESCRIPTION
Fixing issue with Carthage not working.

Cartfile:
```
github "dokun1/Lumina" "master"
```

Run:
```
$ carthage update --platform iOS --cache-builds
```

Error:
```
*** Fetching Lumina
*** Checking out Lumina at "3c8bf3a52ba269e5247f6fb1e4f0133cea7c7b6e"
Parse error: expected submodule commit SHA in output of task (ls-tree -z 3c8bf3a52ba269e5247f6fb1e4f0133cea7c7b6e swift-log) but encountered:
```

Solution:
```
rm -rf .gitmodules
```