### PR TITLE
set camera to continuousAutoFocus

### DIFF
--- a/Lumina/Lumina/Camera/Extensions/FocusHandlerExtension.swift
+++ b/Lumina/Lumina/Camera/Extensions/FocusHandlerExtension.swift
@@ -18,7 +18,7 @@ extension LuminaCamera {
             do {
                 if input.device.isFocusModeSupported(.autoFocus) && input.device.isFocusPointOfInterestSupported {
                     try input.device.lockForConfiguration()
-                    input.device.focusMode = .autoFocus
+                    input.device.focusMode = .continuousAutoFocus
                     input.device.focusPointOfInterest = CGPoint(x: focusPoint.x, y: focusPoint.y)
                     if input.device.isExposureModeSupported(.autoExpose) && input.device.isExposurePointOfInterestSupported {
                         input.device.exposureMode = .autoExpose


### PR DESCRIPTION
in the handler that is called 1 second after tap to autofocus, set the camera mode to continuous autofocus.

<!--- Provide a general summary of your changes in the Title above -->
in the handler that is called 1 second after tap to autofocus, set the camera mode to continuous autofocus. Before, it was setting to autoFocus without continuous mode.

## Description
in FocusHandlerExtension func resetCameraToContinuousExposureAndFocus()
changed .autoFocus to .continuousAutoFocus

## Motivation and Context
https://github.com/dokun1/Lumina/issues/99

## How Has This Been Tested?
with this fix, after tapping to focus on a point for 1 second, the camera mode successfully returns to continuous autofocus.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
