### PR TITLE
set camera to continuousAutoFocus

### DIFF
--- a/Lumina/Lumina/Camera/Extensions/FocusHandlerExtension.swift
+++ b/Lumina/Lumina/Camera/Extensions/FocusHandlerExtension.swift
@@ -42,7 +42,7 @@ extension LuminaCamera {
             }
             if input.device.isFocusModeSupported(.continuousAutoFocus) {
                 try input.device.lockForConfiguration()
-                input.device.focusMode = .autoFocus
+                input.device.focusMode = .continuousAutoFocus
                 if input.device.isExposureModeSupported(.continuousAutoExposure) {
                     input.device.exposureMode = .continuousAutoExposure
                 }


### PR DESCRIPTION
in func resetCameraToContinuousExposureAndFocus() set to input.device.focusMode = .continuousAutoFocus

<!--- Provide a general summary of your changes in the Title above -->
in func resetCameraToContinuousExposureAndFocus() set to input.device.focusMode = .continuousAutoFocus where it used to be set to .autoFocus.  I believe this is a simple fix for a copy-paste bug.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#99 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tap to focus the camera, wait 1 second, verify that continuous autofocus mode for the camera resumes successfully.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
