### PR TITLE
No more availability checks

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,8 +1,11 @@
 disabled_rules:
   - line_length
+  - switch_case_alignment
 file_length:
   warning: 600
   error: 1000
+excluded:
+  - .build/*
 type_body_length:
   - 300 # warning
   - 400 # error

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
   name: "Lumina",
   platforms: [.iOS(.v13)],
   products: [
-    .library(name: "Lumina",targets: ["Lumina"]),
+    .library(name: "Lumina", targets: ["Lumina"])
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0")
@@ -16,6 +16,6 @@ let package = Package(
     .target(name: "Lumina", dependencies: [
       .product(name: "Logging", package: "swift-log")
     ]),
-    .testTarget(name: "LuminaTests", dependencies: ["Lumina"]),
+    .testTarget(name: "LuminaTests", dependencies: ["Lumina"])
   ]
 )

--- a/README.md
+++ b/README.md
@@ -235,24 +235,20 @@ func tapped(from controller: LuminaViewController, at: CGPoint) {
 To handle a `CoreML` model and its predictions being streamed with each video frame, implement:
 ```swift
 func streamed(videoFrame: UIImage, with predictions: [LuminaRecognitionResult]?, from controller: LuminaViewController) {
-    if #available(iOS 11.0, *) {
-        guard let predicted = predictions else {
-            return
-        }
-        var resultString = String()
-        for prediction in predicted {
-            guard let values = prediction.predictions else {
-                continue
-            }
-            guard let bestPrediction = values.first else {
-                continue
-            }
-            resultString.append("\(String(describing: prediction.type)): \(bestPrediction.name)" + "\r\n")
-        }
-        controller.textPrompt = resultString
-    } else {
-        print("CoreML not available in iOS 10.0")
+  guard let predicted = predictions else {
+    return
+  }
+  var resultString = String()
+  for prediction in predicted {
+    guard let values = prediction.predictions else {
+      continue
     }
+    guard let bestPrediction = values.first else {
+      continue
+    }
+    resultString.append("\(String(describing: prediction.type)): \(bestPrediction.name)" + "\r\n")
+  }
+  controller.textPrompt = resultString
 }
 ```
 

--- a/Sample/LuminaSample.xcodeproj/project.pbxproj
+++ b/Sample/LuminaSample.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		5365BFD31F79829800B8F338 /* ImageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewController.swift; sourceTree = "<group>"; };
 		5365BFD91F79AA9B00B8F338 /* MobileNet.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; name = MobileNet.mlmodel; path = LuminaSample/MobileNet.mlmodel; sourceTree = "<group>"; };
 		5373B3F01FC61BBF00C197BD /* SqueezeNet.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; name = SqueezeNet.mlmodel; path = LuminaSample/SqueezeNet.mlmodel; sourceTree = "<group>"; };
-		53B2CE261FF5D434008287E6 /* Lumina.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Lumina.framework; path = "../../../Library/Developer/Xcode/DerivedData/Lumina-ayddllynafnebvdypcqglyhzrbnw/Build/Products/Debug-iphoneos/Lumina.framework"; sourceTree = "<group>"; };
 		53B2CE381FF81302008287E6 /* LoggingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingViewController.swift; sourceTree = "<group>"; };
 		53B828F31EAAA09000E3A624 /* LuminaSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LuminaSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		53B828F61EAAA09000E3A624 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -107,7 +106,6 @@
 		53B829081EAAA16D00E3A624 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				53B2CE261FF5D434008287E6 /* Lumina.framework */,
 				5365BFD91F79AA9B00B8F338 /* MobileNet.mlmodel */,
 				5373B3F01FC61BBF00C197BD /* SqueezeNet.mlmodel */,
 			);

--- a/Sample/LuminaSample/ImageViewController.swift
+++ b/Sample/LuminaSample/ImageViewController.swift
@@ -53,12 +53,9 @@ class ImageViewController: UIViewController, UIScrollViewDelegate {
     if livePhotoURL != nil {
       self.livePhotoButton.isEnabled = true
     }
-    if #available(iOS 11.0, *) {
-      if depthData != nil {
-        self.depthDataButton.isEnabled = true
-      }
+    if depthData != nil {
+      self.depthDataButton.isEnabled = true
     }
-
   }
 
   // MARK: - Scrollview functionality.
@@ -99,19 +96,17 @@ class ImageViewController: UIViewController, UIScrollViewDelegate {
   }
 
   @IBAction func depthDataButtonTapped() {
-    if #available(iOS 11.0, *) {
-      if let data = depthData {
-        if self.showingDepth == false {
-          if let map = data.depthDataMap.normalizedImage(with: self.position) {
-            self.imageView.image = map
-          } else {
-            self.showingDepth = true
-          }
+    if let data = depthData {
+      if self.showingDepth == false {
+        if let map = data.depthDataMap.normalizedImage(with: self.position) {
+          self.imageView.image = map
         } else {
-          self.imageView.image = self.image
+          self.showingDepth = true
         }
-        self.showingDepth = !self.showingDepth
+      } else {
+        self.imageView.image = self.image
       }
+      self.showingDepth = !self.showingDepth
     }
   }
 }

--- a/Sample/LuminaSample/ImageViewController.swift
+++ b/Sample/LuminaSample/ImageViewController.swift
@@ -46,7 +46,7 @@ class ImageViewController: UIViewController, UIScrollViewDelegate {
 
     //Tap gesture recognizer setup.
     doubleTap.numberOfTapsRequired = 2
-    doubleTap.addTarget(self, action: #selector(ImageViewController.ZoomInOnPhoto))
+    doubleTap.addTarget(self, action: #selector(ImageViewController.zoomInOnPhoto))
     scrollView.addGestureRecognizer(doubleTap)
 
     self.imageView.image = self.image
@@ -65,7 +65,7 @@ class ImageViewController: UIViewController, UIScrollViewDelegate {
   //END OF SCROLLVIEW FUNCTIONALITY
 
   // MARK: - Tap to zoom functionality.
-  @objc func ZoomInOnPhoto(recognizer: UITapGestureRecognizer) {
+  @objc func zoomInOnPhoto(recognizer: UITapGestureRecognizer) {
     if scrollView.zoomScale == 1 {
       scrollView.zoom(to: zoomRectForScale(scale: 2, center: recognizer.location(in: recognizer.view)), animated: true)
     } else {

--- a/Sample/LuminaSample/ViewController.swift
+++ b/Sample/LuminaSample/ViewController.swift
@@ -83,9 +83,7 @@ extension ViewController { // MARK: IBActions
       if let map = sender as? [String: Any] {
         controller.image = map["stillImage"] as? UIImage
         controller.livePhotoURL = map["livePhotoURL"] as? URL
-        if #available(iOS 11.0, *) {
-          controller.depthData = map["depthData"] as? AVDepthData
-        }
+        controller.depthData = map["depthData"] as? AVDepthData
         let positionBool = map["isPhotoSelfie"] as! Bool
         controller.position = positionBool ? .front : .back
       } else { return }
@@ -101,25 +99,22 @@ extension ViewController { // MARK: IBActions
 
 extension ViewController: LuminaDelegate {
   func streamed(videoFrame: UIImage, with predictions: [LuminaRecognitionResult]?, from controller: LuminaViewController) {
-    if #available(iOS 11.0, *) {
-      guard let predicted = predictions else {
-        return
-      }
-      var resultString = String()
-      for prediction in predicted {
-        guard let values = prediction.predictions else {
-          continue
-        }
-        guard let bestPrediction = values.first else {
-          continue
-        }
-        resultString.append("\(String(describing: prediction.type)): \(bestPrediction.name)" + "\r\n")
-      }
-      controller.textPrompt = resultString
-    } else {
-      print("CoreML not available in iOS 10.0")
+    guard let predicted = predictions else {
+      return
     }
+    var resultString = String()
+    for prediction in predicted {
+      guard let values = prediction.predictions else {
+        continue
+      }
+      guard let bestPrediction = values.first else {
+        continue
+      }
+      resultString.append("\(String(describing: prediction.type)): \(bestPrediction.name)" + "\r\n")
+    }
+    controller.textPrompt = resultString
   }
+
   func captured(stillImage: UIImage, livePhotoAt: URL?, depthData: Any?, from controller: LuminaViewController) {
     controller.dismiss(animated: true) {
       self.performSegue(withIdentifier: "stillImageOutputSegue", sender: ["stillImage": stillImage, "livePhotoURL": livePhotoAt as Any, "depthData": depthData as Any, "isPhotoSelfie": controller.position == .front ? true : false])
@@ -146,22 +141,20 @@ extension ViewController: LuminaDelegate {
   }
 
   func streamed(depthData: Any, from controller: LuminaViewController) {
-    if #available(iOS 11.0, *) {
-      if let data = depthData as? AVDepthData {
-        guard let image = data.depthDataMap.normalizedImage(with: controller.position) else {
-          print("could not convert depth data")
-          return
-        }
-        if let imageView = self.depthView {
-          imageView.removeFromSuperview()
-        }
-        let newView = UIImageView(frame: CGRect(x: controller.view.frame.minX, y: controller.view.frame.maxY - 300, width: 200, height: 200))
-        newView.image = image
-        newView.contentMode = .scaleAspectFit
-        newView.backgroundColor = UIColor.clear
-        controller.view.addSubview(newView)
-        controller.view.bringSubviewToFront(newView)
+    if let data = depthData as? AVDepthData {
+      guard let image = data.depthDataMap.normalizedImage(with: controller.position) else {
+        print("could not convert depth data")
+        return
       }
+      if let imageView = self.depthView {
+        imageView.removeFromSuperview()
+      }
+      let newView = UIImageView(frame: CGRect(x: controller.view.frame.minX, y: controller.view.frame.maxY - 300, width: 200, height: 200))
+      newView.image = image
+      newView.contentMode = .scaleAspectFit
+      newView.backgroundColor = UIColor.clear
+      controller.view.addSubview(newView)
+      controller.view.bringSubviewToFront(newView)
     }
   }
 

--- a/Sample/LuminaSample/ViewController.swift
+++ b/Sample/LuminaSample/ViewController.swift
@@ -79,19 +79,19 @@ extension ViewController { // MARK: IBActions
 
   override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
     if segue.identifier == "stillImageOutputSegue" {
-      let controller = segue.destination as! ImageViewController
+      guard let controller = segue.destination as? ImageViewController else { return }
       if let map = sender as? [String: Any] {
         controller.image = map["stillImage"] as? UIImage
         controller.livePhotoURL = map["livePhotoURL"] as? URL
         controller.depthData = map["depthData"] as? AVDepthData
-        let positionBool = map["isPhotoSelfie"] as! Bool
+        guard let positionBool = map["isPhotoSelfie"] as? Bool else { return }
         controller.position = positionBool ? .front : .back
       } else { return }
     } else if segue.identifier == "selectResolutionSegue" {
-      let controller = segue.destination as! ResolutionViewController
+      guard let controller = segue.destination as? ResolutionViewController else { return }
       controller.delegate = self
     } else if segue.identifier == "selectLoggingLevelSegue" {
-      let controller = segue.destination as! LoggingViewController
+      guard let controller = segue.destination as? LoggingViewController else { return }
       controller.delegate = self
     }
   }

--- a/Sources/Lumina/Camera/Extensions/CameraActionsExtension.swift
+++ b/Sources/Lumina/Camera/Extensions/CameraActionsExtension.swift
@@ -19,11 +19,9 @@ extension LuminaCamera {
   func captureStillImage() {
     LuminaLogger.info(message: "Attempting photo capture")
     var settings = AVCapturePhotoSettings()
-    if #available(iOS 11.0, *) {
-      if self.photoOutput.availablePhotoCodecTypes.contains(.hevc) {
-        LuminaLogger.notice(message: "Will capture photo with HEVC codec")
-        settings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.hevc])
-      }
+    if self.photoOutput.availablePhotoCodecTypes.contains(.hevc) {
+      LuminaLogger.notice(message: "Will capture photo with HEVC codec")
+      settings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.hevc])
     }
     switch self.torchState {
         //swiftlint:disable empty_enum_arguments
@@ -42,11 +40,9 @@ extension LuminaCamera {
     if self.captureHighResolutionImages {
       settings.isHighResolutionPhotoEnabled = true
     }
-    if #available(iOS 11.0, *) {
-      if self.captureDepthData && self.photoOutput.isDepthDataDeliverySupported {
-        LuminaLogger.notice(message: "depth data delivery is enabled")
-        settings.isDepthDataDeliveryEnabled = true
-      }
+    if self.captureDepthData && self.photoOutput.isDepthDataDeliverySupported {
+      LuminaLogger.notice(message: "depth data delivery is enabled")
+      settings.isDepthDataDeliveryEnabled = true
     }
     self.photoOutput.capturePhoto(with: settings, delegate: self)
   }

--- a/Sources/Lumina/Camera/Extensions/CameraActionsExtension.swift
+++ b/Sources/Lumina/Camera/Extensions/CameraActionsExtension.swift
@@ -24,7 +24,6 @@ extension LuminaCamera {
       settings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.hevc])
     }
     switch self.torchState {
-        //swiftlint:disable empty_enum_arguments
       case .on(_):
         settings.flashMode = .on
       case .off:

--- a/Sources/Lumina/Camera/Extensions/CaptureDeviceHandlerExtension.swift
+++ b/Sources/Lumina/Camera/Extensions/CaptureDeviceHandlerExtension.swift
@@ -54,24 +54,20 @@ extension LuminaCamera {
       if let dataOutput = oldOutput as? AVCaptureVideoDataOutput {
         self.session.removeOutput(dataOutput)
       }
-      if #available(iOS 11.0, *) {
-        if let depthOutput = oldOutput as? AVCaptureDepthDataOutput {
-          self.session.removeOutput(depthOutput)
-        }
+      if let depthOutput = oldOutput as? AVCaptureDepthDataOutput {
+        self.session.removeOutput(depthOutput)
       }
     }
   }
 
   func getDevice(with position: AVCaptureDevice.Position) -> AVCaptureDevice? {
-#if swift(>=4.0.2)
-    if #available(iOS 11.1, *), position == .front {
+    if position == .front {
       if let device = AVCaptureDevice.default(.builtInTrueDepthCamera, for: .video, position: .front) {
         self.currentCaptureDevice = device
         return device
       }
     }
-#endif
-    if #available(iOS 10.2, *), let device = AVCaptureDevice.default(.builtInDualCamera, for: .video, position: position) {
+    if let device = AVCaptureDevice.default(.builtInDualCamera, for: .video, position: position) {
       self.currentCaptureDevice = device
       return device
     } else if let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: position) {

--- a/Sources/Lumina/Camera/Extensions/CapturePhotoExtension.swift
+++ b/Sources/Lumina/Camera/Extensions/CapturePhotoExtension.swift
@@ -9,14 +9,18 @@
 import UIKit
 import AVFoundation
 
-@available (iOS 11.0, *)
 extension AVCapturePhoto {
   func normalizedImage(forCameraPosition position: CameraPosition) -> UIImage? {
     LuminaLogger.notice(message: "normalizing image from AVCapturePhoto instance")
     guard let cgImage = self.cgImageRepresentation() else {
       return nil
     }
-    return UIImage(cgImage: cgImage as! CGImage, scale: 1.0, orientation: getImageOrientation(forCamera: position))
+    #if swift(>=5.5)
+    return UIImage(cgImage: cgImage, scale: 1.0, orientation: getImageOrientation(forCamera: position))
+    #else
+    return UIImage(cgImage: cgImage.takeUnretainedValue(), scale: 1.0, orientation: getImageOrientation(forCamera: position))
+    #endif
+    
   }
 
   private func getImageOrientation(forCamera: CameraPosition) -> UIImage.Orientation {

--- a/Sources/Lumina/Camera/Extensions/CapturePhotoExtension.swift
+++ b/Sources/Lumina/Camera/Extensions/CapturePhotoExtension.swift
@@ -20,7 +20,7 @@ extension AVCapturePhoto {
     #else
     return UIImage(cgImage: cgImage.takeUnretainedValue(), scale: 1.0, orientation: getImageOrientation(forCamera: position))
     #endif
-    
+
   }
 
   private func getImageOrientation(forCamera: CameraPosition) -> UIImage.Orientation {

--- a/Sources/Lumina/Camera/Extensions/Delegates/PhotoCaptureDelegateExtension.swift
+++ b/Sources/Lumina/Camera/Extensions/Delegates/PhotoCaptureDelegateExtension.swift
@@ -33,20 +33,4 @@ extension LuminaCamera: AVCapturePhotoCaptureDelegate {
       }
     }
   }
-
-  // swiftlint:disable function_parameter_count
-  func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photoSampleBuffer: CMSampleBuffer?, previewPhoto previewPhotoSampleBuffer: CMSampleBuffer?, resolvedSettings: AVCaptureResolvedPhotoSettings, bracketSettings: AVCaptureBracketedStillImageSettings?, error: Error?) {
-    if #available(iOS 11.0, *) { // make use of AVCapturePhotoOutput
-      LuminaLogger.warning(message: "using iOS 11.0 or better - discarding output in favor of AVCapturePhoto methods")
-      return
-    } else {
-      guard let buffer = photoSampleBuffer else {
-        return
-      }
-      guard let image = buffer.normalizedStillImage(forCameraPosition: self.position) else {
-        return
-      }
-      delegate?.stillImageCaptured(camera: self, image: image, livePhotoURL: nil, depthData: nil)
-    }
-  }
 }

--- a/Sources/Lumina/Camera/Extensions/Delegates/VideoDataOutputSampleBufferDelegateExtension.swift
+++ b/Sources/Lumina/Camera/Extensions/Delegates/VideoDataOutputSampleBufferDelegateExtension.swift
@@ -14,30 +14,24 @@ extension LuminaCamera: AVCaptureVideoDataOutputSampleBufferDelegate {
     guard let image = sampleBuffer.normalizedVideoFrame() else {
       return
     }
-    if #available(iOS 11.0, *) {
-      if let modelPairs = self.streamingModels {
-        LuminaLogger.notice(message: "valid CoreML models present - attempting to scan photo")
-        if self.recognizer == nil {
-          let newRecognizer = LuminaObjectRecognizer(modelPairs: modelPairs)
-          self.recognizer = newRecognizer
-        }
-        guard let recognizer = self.recognizer as? LuminaObjectRecognizer else {
-          LuminaLogger.error(message: "models loaded, but could not use object recognizer")
-          DispatchQueue.main.async {
-            self.delegate?.videoFrameCaptured(camera: self, frame: image)
-          }
-          return
-        }
-        recognizer.recognize(from: image, completion: { results in
-          DispatchQueue.main.async {
-            self.delegate?.videoFrameCaptured(camera: self, frame: image, predictedObjects: results)
-          }
-        })
-      } else {
+    if let modelPairs = self.streamingModels {
+      LuminaLogger.notice(message: "valid CoreML models present - attempting to scan photo")
+      if self.recognizer == nil {
+        let newRecognizer = LuminaObjectRecognizer(modelPairs: modelPairs)
+        self.recognizer = newRecognizer
+      }
+      guard let recognizer = self.recognizer as? LuminaObjectRecognizer else {
+        LuminaLogger.error(message: "models loaded, but could not use object recognizer")
         DispatchQueue.main.async {
           self.delegate?.videoFrameCaptured(camera: self, frame: image)
         }
+        return
       }
+      recognizer.recognize(from: image, completion: { results in
+        DispatchQueue.main.async {
+          self.delegate?.videoFrameCaptured(camera: self, frame: image, predictedObjects: results)
+        }
+      })
     } else {
       DispatchQueue.main.async {
         self.delegate?.videoFrameCaptured(camera: self, frame: image)

--- a/Sources/Lumina/Camera/Extensions/SessionConfigurationExtension.swift
+++ b/Sources/Lumina/Camera/Extensions/SessionConfigurationExtension.swift
@@ -162,7 +162,7 @@ extension LuminaCamera {
         return .invalidVideoFileOutput
       }
     }
-    if #available(iOS 11.0, *), let depthDataOutput = self.depthDataOutput {
+    if let depthDataOutput = self.depthDataOutput {
       guard self.session.canAddOutput(depthDataOutput) else {
         LuminaLogger.error(message: "cannot add depth data output with this settings map")
         return .invalidDepthDataOutput

--- a/Sources/Lumina/Camera/LuminaCamera.swift
+++ b/Sources/Lumina/Camera/LuminaCamera.swift
@@ -13,7 +13,6 @@ import CoreML
 protocol LuminaCameraDelegate: class {
   func stillImageCaptured(camera: LuminaCamera, image: UIImage, livePhotoURL: URL?, depthData: Any?)
   func videoFrameCaptured(camera: LuminaCamera, frame: UIImage)
-  @available (iOS 11.0, *)
   func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [LuminaRecognitionResult]?)
   func depthDataCaptured(camera: LuminaCamera, depthData: Any)
   func videoRecordingCaptured(camera: LuminaCamera, videoURL: URL)
@@ -166,7 +165,7 @@ final class LuminaCamera: NSObject {
   var recognizer: AnyObject?
 
   private var _streamingModels: [(AnyObject, String)]?
-  @available(iOS 11.0, *)
+
   var streamingModels: [LuminaModel]? {
     get {
       if let existingModels = _streamingModels {
@@ -203,14 +202,12 @@ final class LuminaCamera: NSObject {
   fileprivate var discoverySession: AVCaptureDevice.DiscoverySession? {
     var deviceTypes = [AVCaptureDevice.DeviceType]()
     deviceTypes.append(.builtInWideAngleCamera)
-    if #available(iOS 10.2, *) {
-      deviceTypes.append(.builtInDualCamera)
-    }
-#if swift(>=4.0.2) // Xcode 9.1 shipped with Swift 4.0.2
-    if #available(iOS 11.1, *), self.captureDepthData == true {
+    deviceTypes.append(.builtInDualCamera)
+    deviceTypes.append(.builtInTripleCamera)
+    deviceTypes.append(.builtInUltraWideCamera)
+    if self.captureDepthData == true {
       deviceTypes.append(.builtInTrueDepthCamera)
     }
-#endif
     return AVCaptureDevice.DiscoverySession(deviceTypes: deviceTypes, mediaType: AVMediaType.video, position: AVCaptureDevice.Position.unspecified)
   }
 
@@ -254,7 +251,6 @@ final class LuminaCamera: NSObject {
   }
 
   private var _depthDataOutput: AnyObject?
-  @available(iOS 11.0, *)
   var depthDataOutput: AVCaptureDepthDataOutput? {
     get {
       if let existingOutput = _depthDataOutput {

--- a/Sources/Lumina/Camera/LuminaPhotoCapture.swift
+++ b/Sources/Lumina/Camera/LuminaPhotoCapture.swift
@@ -25,7 +25,6 @@ struct LuminaPhotoCapture {
   }
 
   private var _depthData: Any?
-  @available(iOS 11.0, *)
   var depthData: AVDepthData? {
     get {
       return _depthData as? AVDepthData

--- a/Sources/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
+++ b/Sources/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
@@ -17,7 +17,7 @@ public protocol LuminaDelegate: class {
   /// - Parameters:
   ///   - stillImage: the image captured by Lumina
   ///   - livePhotoAt: the URL where the live photo file can be located and used, if enabled and available
-  ///   - depthData: the depth data associated with the captured still image, if enabled and available (iOS 11.0 only)
+  ///   - depthData: the depth data associated with the captured still image, if enabled and available
   ///   - controller: the instance of Lumina that captured the still image
   func captured(stillImage: UIImage, livePhotoAt: URL?, depthData: Any?, from controller: LuminaViewController)
 
@@ -49,7 +49,6 @@ public protocol LuminaDelegate: class {
   /// Triggered whenever streamDepthData is set to true on Lumina, and streams depth data detected in the form of AVDepthData
   ///
   /// - Warning: This data is returned from type `Any`, and must be optionally downcast to `AVDepthData` by the user of Lumina. This is to maintain backwards compatibility with iOS 10.0
-  /// - Note: This is only available on iOS 11.0
   /// - Parameters:
   ///   - depthData: buffer containing AVDepthData relevant to the streamed video frame
   ///   - controller: the instance of Lumina that is streaming the depth data

--- a/Sources/Lumina/UI/Extensions/ViewControllerButtonFunctions.swift
+++ b/Sources/Lumina/UI/Extensions/ViewControllerButtonFunctions.swift
@@ -77,7 +77,6 @@ extension LuminaViewController {
         LuminaLogger.notice(message: "torch mode should be set to on")
         camera.torchState = .on(intensity: 1.0)
         self.torchButton.updateTorchIcon(to: SystemButtonType.FlashState.on)
-        //swiftlint:disable empty_enum_arguments
       case .on(_):
         LuminaLogger.notice(message: "torch mode should be set to auto")
         camera.torchState = .auto

--- a/Sources/Lumina/UI/LuminaButton.swift
+++ b/Sources/Lumina/UI/LuminaButton.swift
@@ -84,10 +84,7 @@ final class LuminaButton: UIButton {
         self.frame = CGRect(origin: CGPoint(x: UIScreen.main.bounds.maxX - 50, y: 10), size: CGSize(width: self.squareSystemButtonWidth, height: self.squareSystemButtonHeight))
       case .shutter:
         self.backgroundColor = UIColor.normalState
-        var minY = UIScreen.main.bounds.maxY
-        if #available(iOS 11, *) {
-          minY = self.safeAreaLayoutGuide.layoutFrame.maxY
-        }
+        var minY = self.safeAreaLayoutGuide.layoutFrame.maxY
         minY -=  80
         self.frame = CGRect(origin: CGPoint(x: UIScreen.main.bounds.midX - 35, y: minY), size: CGSize(width: self.shutterButtonDimension, height: self.shutterButtonDimension))
         self.layer.cornerRadius = CGFloat(self.shutterButtonDimension / 2)


### PR DESCRIPTION
Lumina used to check whether iOS 11 was available - mostly to see whether CoreML was possible.

## Description
As of 1.6.0, Lumina requires iOS 13 as the minimum. No APIs in Lumina currently need anything higher than 13.0. Thus, this change is cosmetic in nature, and the API should be intact. There should be zero `@available()` checks in Lumina now

## Motivation and Context
I eventually plan to contribute some Combine subscriptions, but also some contour checking.

## How Has This Been Tested?
All existing functionality tested in sample app.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
