### PR TITLE
Removed all warnings, no more MLModel casting

### DIFF
--- a/Sample/LuminaSample/LoggingViewController.swift
+++ b/Sample/LuminaSample/LoggingViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import Lumina
 import Logging
 
-protocol LoggingLevelDelegate: class {
+protocol LoggingLevelDelegate: AnyObject {
   func didSelect(loggingLevel: Logger.Level, controller: LoggingViewController)
 }
 

--- a/Sample/LuminaSample/ResolutionViewController.swift
+++ b/Sample/LuminaSample/ResolutionViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Lumina
 
-protocol ResolutionDelegate: class {
+protocol ResolutionDelegate: AnyObject {
   func didSelect(resolution: CameraResolution, controller: ResolutionViewController)
 }
 

--- a/Sources/Lumina/Camera/Extensions/CapturePhotoExtension.swift
+++ b/Sources/Lumina/Camera/Extensions/CapturePhotoExtension.swift
@@ -24,7 +24,7 @@ extension AVCapturePhoto {
   }
 
   private func getImageOrientation(forCamera: CameraPosition) -> UIImage.Orientation {
-    switch UIApplication.shared.statusBarOrientation {
+    switch LuminaViewController.orientation {
       case .landscapeLeft:
         return forCamera == .back ? .down : .upMirrored
       case .landscapeRight:

--- a/Sources/Lumina/Camera/Extensions/SampleBufferExtension.swift
+++ b/Sources/Lumina/Camera/Extensions/SampleBufferExtension.swift
@@ -10,20 +10,6 @@ import UIKit
 import AVFoundation
 
 extension CMSampleBuffer {
-  func normalizedStillImage(forCameraPosition position: CameraPosition) -> UIImage? {
-    LuminaLogger.notice(message: "normalizing still image from CMSampleBuffer")
-    guard let imageData = AVCapturePhotoOutput.jpegPhotoDataRepresentation(forJPEGSampleBuffer: self, previewPhotoSampleBuffer: nil) else {
-      return nil
-    }
-    guard let dataProvider = CGDataProvider(data: imageData as CFData) else {
-      return nil
-    }
-    guard let cgImageRef = CGImage(jpegDataProviderSource: dataProvider, decode: nil, shouldInterpolate: true, intent: CGColorRenderingIntent.defaultIntent) else {
-      return nil
-    }
-    return UIImage(cgImage: cgImageRef, scale: 1.0, orientation: getImageOrientation(forCamera: position))
-  }
-
   func normalizedVideoFrame() -> UIImage? {
     LuminaLogger.notice(message: "normalizing video frame from CMSampleBbuffer")
     guard let imageBuffer = CMSampleBufferGetImageBuffer(self) else {
@@ -38,7 +24,7 @@ extension CMSampleBuffer {
   }
 
   private func getImageOrientation(forCamera: CameraPosition) -> UIImage.Orientation {
-    switch UIApplication.shared.statusBarOrientation {
+    switch LuminaViewController.orientation {
       case .landscapeLeft:
         return forCamera == .back ? .down : .upMirrored
       case .landscapeRight:

--- a/Sources/Lumina/Camera/LuminaCamera.swift
+++ b/Sources/Lumina/Camera/LuminaCamera.swift
@@ -10,7 +10,7 @@ import UIKit
 import AVFoundation
 import CoreML
 
-protocol LuminaCameraDelegate: class {
+protocol LuminaCameraDelegate: AnyObject {
   func stillImageCaptured(camera: LuminaCamera, image: UIImage, livePhotoURL: URL?, depthData: Any?)
   func videoFrameCaptured(camera: LuminaCamera, frame: UIImage)
   func videoFrameCaptured(camera: LuminaCamera, frame: UIImage, predictedObjects: [LuminaRecognitionResult]?)
@@ -164,38 +164,7 @@ final class LuminaCamera: NSObject {
 
   var recognizer: AnyObject?
 
-  private var _streamingModels: [(AnyObject, String)]?
-
-  var streamingModels: [LuminaModel]? {
-    get {
-      if let existingModels = _streamingModels {
-        var models = [LuminaModel]()
-        for potentialModel in existingModels {
-          if let model = potentialModel.0 as? MLModel {
-            models.append(LuminaModel(model: model, type: potentialModel.1))
-          }
-        }
-        guard models.count > 0 else {
-          return nil
-        }
-        return models
-      } else {
-        return nil
-      }
-    }
-    set {
-      if let tuples = newValue {
-        var downcastCollection = [(AnyObject, String)]()
-        for tuple in tuples {
-          guard let model = tuple.model, let type = tuple.type else {
-            continue
-          }
-          downcastCollection.append((model as AnyObject, type))
-        }
-        _streamingModels = downcastCollection
-      }
-    }
-  }
+  var streamingModels: [LuminaModel]?
 
   var session = AVCaptureSession()
 

--- a/Sources/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
+++ b/Sources/Lumina/UI/Extensions/Delegates/LuminaDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 import CoreML
 
 /// Delegate for returning information to the application utilizing Lumina
-public protocol LuminaDelegate: class {
+public protocol LuminaDelegate: AnyObject {
 
   /// Triggered whenever a still image is captured by the user of Lumina
   ///

--- a/Sources/Lumina/UI/Extensions/InterfaceHandlerExtension.swift
+++ b/Sources/Lumina/UI/Extensions/InterfaceHandlerExtension.swift
@@ -77,7 +77,7 @@ extension LuminaViewController {
         case .videoSuccess:
           if let camera = self.camera {
             self.enableUI(valid: true)
-            self.updateUI(orientation: UIApplication.shared.statusBarOrientation)
+            self.updateUI(orientation: LuminaViewController.orientation)
             camera.start()
           }
         case .audioSuccess:

--- a/Sources/Lumina/UI/LuminaViewController.swift
+++ b/Sources/Lumina/UI/LuminaViewController.swift
@@ -347,7 +347,7 @@ open class LuminaViewController: UIViewController {
       }
     }
   }
-  
+
   static var orientation: UIInterfaceOrientation {
     UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.windowScene?.interfaceOrientation  ?? .portrait
   }

--- a/Sources/Lumina/UI/LuminaViewController.swift
+++ b/Sources/Lumina/UI/LuminaViewController.swift
@@ -239,27 +239,11 @@ open class LuminaViewController: UIViewController {
   }
 
   /// A collection of model types that will be used when streaming images for object recognition
-  ///
-  /// - Note: Only works on iOS 11 and up
-  ///
   /// - Warning: If this is set, streamFrames is over-ridden to true
-  open var streamingModels: [AnyObject]? {
+  open var streamingModels: [LuminaModel]? {
     didSet {
-      guard let streamingModels = self.streamingModels else {
-        return
-      }
-      var properlyCastModels = [LuminaModel]()
-      for possibleModel in streamingModels {
-        guard let model = possibleModel as? LuminaModel else {
-          continue
-        }
-        properlyCastModels.append(model)
-      }
-      if properlyCastModels.count > 0 {
-        LuminaLogger.notice(message: "Valid models loaded - frame streaming mode defaulted to on")
-        self.streamFrames = true
-        self.camera?.streamingModels = properlyCastModels
-      }
+      self.camera?.streamingModels = streamingModels
+      self.streamFrames = true
     }
   }
 
@@ -353,7 +337,7 @@ open class LuminaViewController: UIViewController {
   open override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     createUI()
-    updateUI(orientation: UIApplication.shared.statusBarOrientation)
+    updateUI(orientation: LuminaViewController.orientation)
     self.camera?.updateVideo { result in
       self.handleCameraSetupResult(result)
     }
@@ -362,6 +346,10 @@ open class LuminaViewController: UIViewController {
         self.handleCameraSetupResult(result)
       }
     }
+  }
+  
+  static var orientation: UIInterfaceOrientation {
+    UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.windowScene?.interfaceOrientation  ?? .portrait
   }
 
   /// override with caution
@@ -389,7 +377,7 @@ open class LuminaViewController: UIViewController {
     if self.camera?.recordingVideo == true {
       return
     }
-    updateUI(orientation: UIApplication.shared.statusBarOrientation)
+    updateUI(orientation: LuminaViewController.orientation)
     updateButtonFrames()
   }
 


### PR DESCRIPTION
This gets rid of every warning in Lumina.

## Description
1. There are now no more warnings that show up in either the Lumina framework or in the associated sample app.
2. I've also removed the need for a `LuminaModel` type to type-erase down to AnyObject incase the device was pre-iOS 11, as iOS 13 is now the minimum for Lumina.

## Motivation and Context
This continues to be an effort to make it easier to work with Lumina for future efforts.

## How Has This Been Tested?
Ran through the sample app, tested every possible scenario available.

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
